### PR TITLE
Fix sentry error

### DIFF
--- a/deployment/docker/requirements.txt
+++ b/deployment/docker/requirements.txt
@@ -16,7 +16,7 @@ uwsgi==2.0.23
 django-webpack-loader==1.8.1
 
 # Python client for Sentry (https://sentry.io)
-sentry-sdk==1.18.0
+sentry-sdk==1.33.0
 
 # Implementation of per object permissions for Django.
 django-guardian==2.4.0

--- a/deployment/docker/uwsgi.conf
+++ b/deployment/docker/uwsgi.conf
@@ -12,8 +12,8 @@ cheaper = 2
 env = DJANGO_SETTINGS_MODULE=core.settings.prod
 # disabled so we run in the foreground for docker
 #daemonize = /tmp/django.log
-req-logger = file:/var/log/uwsgi-requests.log
-logger = file:/var/log/uwsgi-errors.log
+# req-logger = file:/var/log/uwsgi-requests.log
+# logger = file:/var/log/uwsgi-errors.log
 #uid = 1000
 #gid = 1000
 memory-report = true


### PR DESCRIPTION
- Disable uwsgi logging to files
- Fix sentry sdk init error

```
Exception ignored in atexit callback: <function AtexitIntegration.setup_once.<locals>._shutdown at 0x7fda24e62de0>
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/sentry_sdk/integrations/atexit.py", line 62, in _shutdown
    client.close(callback=integration.callback)
  File "/usr/local/lib/python3.12/site-packages/sentry_sdk/client.py", line 565, in close
    self.flush(timeout=timeout, callback=callback)
  File "/usr/local/lib/python3.12/site-packages/sentry_sdk/client.py", line 587, in flush
    self.transport.flush(timeout=timeout, callback=callback)
  File "/usr/local/lib/python3.12/site-packages/sentry_sdk/transport.py", line 492, in flush
    self._worker.submit(lambda: self._flush_client_reports(force=True))
  File "/usr/local/lib/python3.12/site-packages/sentry_sdk/worker.py", line 113, in submit
    self._ensure_thread()
  File "/usr/local/lib/python3.12/site-packages/sentry_sdk/worker.py", line 42, in _ensure_thread
    self.start()
  File "/usr/local/lib/python3.12/site-packages/sentry_sdk/worker.py", line 70, in start
    self._thread.start()
  File "/usr/local/lib/python3.12/site-packages/sentry_sdk/integrations/threading.py", line 54, in sentry_start
    return old_start(self, *a, **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/threading.py", line 971, in start
    _start_new_thread(self._bootstrap, ())
RuntimeError: can't create new thread at interpreter shutdown
```