### PR TITLE
Optimize Salient Ingestor

### DIFF
--- a/deployment/docker/requirements-dev.txt
+++ b/deployment/docker/requirements-dev.txt
@@ -19,3 +19,6 @@ mock==4.0.3
 pytest-django
 # mock requests
 requests-mock
+
+# memory profiler
+memory-profiler

--- a/django_project/gap/ingestor/salient.py
+++ b/django_project/gap/ingestor/salient.py
@@ -512,7 +512,6 @@ class SalientIngestor(BaseIngestor):
                     non_ensemble_chunks if var_name.endswith('_clim') else
                     ensemble_chunks
                 )
-                
             }
 
         if self.created:

--- a/django_project/gap/ingestor/salient.py
+++ b/django_project/gap/ingestor/salient.py
@@ -216,6 +216,14 @@ class SalientCollector(BaseIngestor):
 class SalientIngestor(BaseIngestor):
     """Ingestor for Salient seasonal forecast data."""
 
+    default_chunks = {
+        'ensemble': 50,
+        'forecast_day': 20,
+        'lat': 20,
+        'lon': 20
+    }
+    forecast_date_chunk = 10
+
     def __init__(self, session: IngestorSession, working_dir: str = '/tmp'):
         """Initialize SalientIngestor."""
         super().__init__(session, working_dir)
@@ -305,7 +313,8 @@ class SalientIngestor(BaseIngestor):
         if not netcdf_url.endswith('/'):
             netcdf_url += '/'
         netcdf_url += f'{source_file.name}'
-        return xr.open_dataset(fs.open(netcdf_url))
+        return xr.open_dataset(
+            fs.open(netcdf_url), chunks=self.default_chunks)
 
     def _update_zarr_source_file(self, forecast_date: datetime.date):
         """Update zarr DataSourceFile start and end datetime.
@@ -382,7 +391,9 @@ class SalientIngestor(BaseIngestor):
             self._update_zarr_source_file(forecast_date)
 
             # delete netcdf datasource file
-            self._remove_temporary_source_file(source_file, file_path)
+            remove_temp_file = self.get_config('remove_temp_file', True)
+            if remove_temp_file:
+                self._remove_temporary_source_file(source_file, file_path)
 
             total_files += 1
             forecast_dates.append(forecast_date.isoformat())
@@ -407,8 +418,20 @@ class SalientIngestor(BaseIngestor):
             f'{forecast_date.isoformat()}', periods=1)
         data_vars = {}
         for var_name, da in dataset.data_vars.items():
-            # Initialize the data_var with the empty array
-            data_vars[var_name] = da.expand_dims('forecast_date', axis=0)
+            if var_name.endswith('_clim'):
+                data_vars[var_name] = da.expand_dims(
+                    'forecast_date',
+                    axis=0
+                ).chunk({
+                    'forecast_day': self.default_chunks['forecast_day'],
+                    'lat': self.default_chunks['lat'],
+                    'lon': self.default_chunks['lon']
+                })
+            else:
+                data_vars[var_name] = da.expand_dims(
+                    'forecast_date',
+                    axis=0
+                ).chunk(self.default_chunks)
 
         # Create the dataset
         zarr_ds = xr.Dataset(
@@ -448,21 +471,61 @@ class SalientIngestor(BaseIngestor):
             tolerance=self.reindex_tolerance
         )
 
+        # rechunk the dataset
+        expanded_ds = expanded_ds.chunk({
+            'forecast_date': self.forecast_date_chunk,
+            'ensemble': self.default_chunks['ensemble'],
+            'forecast_day_idx': self.default_chunks['forecast_day'],
+            'lat': self.default_chunks['lat'],
+            'lon': self.default_chunks['lon']
+        })
+
         # write to zarr
         zarr_url = (
             BaseZarrReader.get_zarr_base_url(self.s3) +
             self.datasource_file.name
         )
+
+        # set chunks for each data var
+        ensemble_chunks = (
+            self.forecast_date_chunk,
+            self.default_chunks['ensemble'],
+            self.default_chunks['forecast_day'],
+            self.default_chunks['lat'],
+            self.default_chunks['lon']
+        )
+        non_ensemble_chunks = (
+            self.forecast_date_chunk,
+            self.default_chunks['forecast_day'],
+            self.default_chunks['lat'],
+            self.default_chunks['lon']
+        )
+        encoding = {
+            'forecast_date': {
+                'chunks': self.forecast_date_chunk
+            }
+        }
+        var_name: str
+        for var_name, da in expanded_ds.data_vars.items():
+            encoding[var_name] = {
+                'chunks': (
+                    non_ensemble_chunks if var_name.endswith('_clim') else
+                    ensemble_chunks
+                )
+                
+            }
+
         if self.created:
             expanded_ds.to_zarr(
                 zarr_url, mode='w', consolidated=True,
-                storage_options=self.s3_options
+                storage_options=self.s3_options,
+                encoding=encoding
             )
         else:
             expanded_ds.to_zarr(
-                zarr_url, mode='a', append_dim='forecast_date',
+                zarr_url, mode='a-', append_dim='forecast_date',
                 consolidated=True,
-                storage_options=self.s3_options
+                storage_options=self.s3_options,
             )
 
     def run(self):

--- a/django_project/gap/providers/cbam.py
+++ b/django_project/gap/providers/cbam.py
@@ -237,11 +237,10 @@ class CBAMZarrReader(BaseZarrReader, CBAMNetCDFReader):
         """
         point = self.location_input.point
         return dataset[variables].sel(
+            **{self.date_variable: slice(start_dt, end_dt)}
+        ).sel(
             lat=point.y,
-            lon=point.x, method='nearest').where(
-                (dataset[self.date_variable] >= start_dt) &
-                (dataset[self.date_variable] <= end_dt),
-                drop=True
+            lon=point.x, method='nearest'
         )
 
     def _read_variables_by_bbox(
@@ -267,11 +266,11 @@ class CBAMZarrReader(BaseZarrReader, CBAMNetCDFReader):
         lon_min = points[0].x
         lon_max = points[1].x
         # output results is in two dimensional array
-        return dataset[variables].where(
-            (dataset.lat >= lat_min) & (dataset.lat <= lat_max) &
-            (dataset.lon >= lon_min) & (dataset.lon <= lon_max) &
-            (dataset[self.date_variable] >= start_dt) &
-            (dataset[self.date_variable] <= end_dt), drop=True)
+        return dataset[variables].sel(
+            lat=slice(lat_min, lat_max),
+            lon=slice(lon_min, lon_max),
+            **{self.date_variable: slice(start_dt, end_dt)}
+        )
 
     def _read_variables_by_polygon(
             self, dataset: xrDataset, variables: List[str],
@@ -296,12 +295,14 @@ class CBAMZarrReader(BaseZarrReader, CBAMNetCDFReader):
 
         # Create a mask using regionmask from the shapely polygon
         mask = regionmask.Regions([shapely_multipolygon]).mask(dataset)
-        # TODO: we should pass the non-NA indices from mask to find_locations
+
         # Mask the dataset
-        return dataset[variables].where(
-            (mask == 0) &
-            (dataset[self.date_variable] >= start_dt) &
-            (dataset[self.date_variable] <= end_dt), drop=True)
+        return dataset[variables].sel(
+            **{self.date_variable: slice(start_dt, end_dt)}
+        ).where(
+            mask == 0,
+            drop=True
+        )
 
     def _read_variables_by_points(
             self, dataset: xrDataset, variables: List[str],
@@ -334,10 +335,12 @@ class CBAMZarrReader(BaseZarrReader, CBAMNetCDFReader):
             }, dims=['lat', 'lon']
         )
         # Apply the mask to the dataset
-        return dataset[variables].where(
-            (mask_da) &
-            (dataset[self.date_variable] >= start_dt) &
-            (dataset[self.date_variable] <= end_dt), drop=True)
+        return dataset[variables].sel(
+            **{self.date_variable: slice(start_dt, end_dt)}
+        ).where(
+            mask_da,
+            drop=True
+        )
 
     def read_historical_data(self, start_date: datetime, end_date: datetime):
         """Read historical data from dataset.

--- a/django_project/gap/providers/salient.py
+++ b/django_project/gap/providers/salient.py
@@ -338,12 +338,10 @@ class SalientZarrReader(BaseZarrReader, SalientNetCDFReader):
         max_idx = self._get_forecast_day_idx(end_dt)
         return dataset[variables].sel(
             forecast_date=self.latest_forecast_date,
+            **{self.date_variable: slice(min_idx, max_idx)}
+        ).sel(
             lat=point.y,
-            lon=point.x, method='nearest').where(
-                (dataset[self.date_variable] >= min_idx) &
-                (dataset[self.date_variable] <= max_idx),
-                drop=True
-        )
+            lon=point.x, method='nearest')
 
     def _read_variables_by_bbox(
             self, dataset: xrDataset, variables: List[str],
@@ -371,13 +369,10 @@ class SalientZarrReader(BaseZarrReader, SalientNetCDFReader):
         max_idx = self._get_forecast_day_idx(end_dt)
         # output results is in two dimensional array
         return dataset[variables].sel(
-            forecast_date=self.latest_forecast_date
-        ).where(
-            (dataset.lat >= lat_min) & (dataset.lat <= lat_max) &
-            (dataset.lon >= lon_min) & (dataset.lon <= lon_max) &
-            (dataset[self.date_variable] >= min_idx) &
-            (dataset[self.date_variable] <= max_idx),
-            drop=True
+            forecast_date=self.latest_forecast_date,
+            lat=slice(lat_min, lat_max),
+            lon=slice(lon_min, lon_max),
+            **{self.date_variable: slice(min_idx, max_idx)}
         )
 
     def _read_variables_by_polygon(
@@ -407,11 +402,10 @@ class SalientZarrReader(BaseZarrReader, SalientNetCDFReader):
         mask = regionmask.Regions([shapely_multipolygon]).mask(dataset)
         # Mask the dataset
         return dataset[variables].sel(
-            forecast_date=self.latest_forecast_date
+            forecast_date=self.latest_forecast_date,
+            **{self.date_variable: slice(min_idx, max_idx)}
         ).where(
-            (mask == 0) &
-            (dataset[self.date_variable] >= min_idx) &
-            (dataset[self.date_variable] <= max_idx),
+            mask == 0,
             drop=True
         )
 
@@ -454,8 +448,9 @@ class SalientZarrReader(BaseZarrReader, SalientNetCDFReader):
         )
         # Apply the mask to the dataset
         return dataset[variables].sel(
-            forecast_date=self.latest_forecast_date
+            forecast_date=self.latest_forecast_date,
+            **{self.date_variable: slice(min_idx, max_idx)}
         ).where(
-            (mask_da) &
-            (dataset[self.date_variable] >= min_idx) &
-            (dataset[self.date_variable] <= max_idx), drop=True)
+            mask_da,
+            drop=True
+        )

--- a/django_project/gap/tests/ingestor/test_salient.py
+++ b/django_project/gap/tests/ingestor/test_salient.py
@@ -291,7 +291,10 @@ class TestSalientIngestor(SalientIngestorBaseTest):
         # Create a mock dataset
         mock_dataset = xrDataset(
             {
-                'temp': (('lat', 'lon'), np.random.rand(2, 2)),
+                'temp': (
+                    ('forecast_day', 'ensemble', 'lat', 'lon'),
+                    np.random.rand(1, 50, 2, 2)
+                ),
             },
             coords={
                 'forecast_day': pd.date_range('2024-08-28', periods=1),
@@ -340,7 +343,10 @@ class TestSalientIngestor(SalientIngestorBaseTest):
         # Mock the open_dataset return value
         mock_dataset = xrDataset(
             {
-                'temp': (('lat', 'lon'), np.random.rand(2, 2)),
+                'temp': (
+                    ('forecast_day', 'ensemble', 'lat', 'lon'),
+                    np.random.rand(1, 50, 2, 2)
+                ),
             },
             coords={
                 'forecast_day': pd.date_range('2024-08-28', periods=1),

--- a/django_project/gap/tests/providers/test_cbam.py
+++ b/django_project/gap/tests/providers/test_cbam.py
@@ -8,16 +8,21 @@ Tomorrow Now GAP.
 from django.test import TestCase
 from datetime import datetime
 import xarray as xr
-from django.contrib.gis.geos import Point
+import numpy as np
+import pandas as pd
+from django.contrib.gis.geos import Point, MultiPoint, Polygon, MultiPolygon
 from unittest.mock import Mock, patch
 
 from core.settings.utils import absolute_path
-from gap.utils.reader import DatasetReaderInput
+from gap.models.dataset import Dataset
+from gap.models.measurement import DatasetAttribute
+from gap.utils.reader import DatasetReaderInput, LocationInputType
 from gap.utils.netcdf import (
     NetCDFProvider,
 )
 from gap.providers import (
-    CBAMNetCDFReader
+    CBAMNetCDFReader,
+    CBAMZarrReader
 )
 from gap.factories import (
     ProviderFactory,
@@ -89,3 +94,110 @@ class TestCBAMNetCDFReader(TestCase):
             self.assertAlmostEqual(
                 data_value['data'][0]['values']['max_temperature'],
                 33.371735, 6)
+
+
+class TestCBAMZarrReader(TestCase):
+    """Test class for CBAMZarrReader."""
+
+    fixtures = [
+        '2.provider.json',
+        '3.observation_type.json',
+        '4.dataset_type.json',
+        '5.dataset.json',
+        '6.unit.json',
+        '7.attribute.json',
+        '8.dataset_attribute.json'
+    ]
+
+    def setUp(self):
+        """Setup test cbam zarr reader."""
+        self.dataset = Dataset.objects.get(name='CBAM Climate Reanalysis')
+        self.attribute1 = DatasetAttribute.objects.filter(
+            dataset=self.dataset,
+            attribute__variable_name='max_temperature'
+        ).first()
+        self.dt1 = np.datetime64('2024-09-01')
+        self.dt2 = np.datetime64('2024-09-01')
+        self.xrDataset = xr.Dataset(
+            {
+                'max_total_temperature': (
+                    ('date', 'lat', 'lon'),
+                    [
+                        [
+                            [0.26790932, 0.5398054],
+                            [0.74384186, 0.50810691]
+                        ]
+                    ]
+                ),
+            },
+            coords={
+                'date': pd.date_range('2024-09-01', periods=1),
+                'lat': [0, 1],
+                'lon': [0, 1],
+            }
+        )
+        dt = datetime(2024, 9, 1, 0, 0, 0)
+        self.reader = CBAMZarrReader(
+            self.dataset, [self.attribute1],
+            DatasetReaderInput.from_point(Point(0, 1)),
+            dt, dt
+        )
+
+    def test_read_from_point(self):
+        """Test read cbam data from single point."""
+        ds = self.reader._read_variables_by_point(
+            self.xrDataset, ['max_total_temperature'],
+            self.dt1, self.dt2
+        )
+        self.assertAlmostEqual(ds['max_total_temperature'], 0.74384186, 2)
+
+    def test_read_from_bbox(self):
+        """Test read cbam data from bbox."""
+        self.reader.location_input = DatasetReaderInput.from_bbox(
+            [0, 0, 1, 1])
+        ds = self.reader._read_variables_by_bbox(
+            self.xrDataset, ['max_total_temperature'],
+            self.dt1, self.dt2
+        )
+        self.assertTrue(
+            np.allclose(
+                self.xrDataset['max_total_temperature'].values,
+                ds['max_total_temperature'].values
+            )
+        )
+
+    def test_read_from_polygon(self):
+        """Test read cbam data from polygon."""
+        self.reader.location_input = DatasetReaderInput(
+            MultiPolygon([Polygon.from_bbox((-1, -1, 2, 2))]),
+            LocationInputType.POLYGON
+        )
+        ds = self.reader._read_variables_by_polygon(
+            self.xrDataset, ['max_total_temperature'],
+            self.dt1, self.dt2
+        )
+        self.assertTrue(
+            np.allclose(
+                self.xrDataset['max_total_temperature'].values,
+                ds['max_total_temperature'].values
+            )
+        )
+
+    def test_read_from_points(self):
+        """Test read cbam data from list of point."""
+        self.reader.location_input = DatasetReaderInput(
+            MultiPoint([
+                Point(x=0, y=0),
+                Point(x=1, y=1)
+            ]),
+            LocationInputType.LIST_OF_POINT
+        )
+        ds = self.reader._read_variables_by_points(
+            self.xrDataset, ['max_total_temperature'],
+            self.dt1, self.dt2
+        )
+        print(ds)
+        val = ds['max_total_temperature'].values
+        print(val)
+        self.assertAlmostEqual(val[0][0][0], 0.26790932)
+        self.assertAlmostEqual(val[0][1][1], 0.50810691)

--- a/django_project/gap/tests/providers/test_cbam.py
+++ b/django_project/gap/tests/providers/test_cbam.py
@@ -110,7 +110,7 @@ class TestCBAMZarrReader(TestCase):
     ]
 
     def setUp(self):
-        """Setup test cbam zarr reader."""
+        """Set test cbam zarr reader."""
         self.dataset = Dataset.objects.get(name='CBAM Climate Reanalysis')
         self.attribute1 = DatasetAttribute.objects.filter(
             dataset=self.dataset,

--- a/django_project/gap/utils/netcdf.py
+++ b/django_project/gap/utils/netcdf.py
@@ -7,6 +7,7 @@ Tomorrow Now GAP.
 
 import os
 import logging
+import traceback
 from typing import List
 from math import ceil
 from datetime import datetime, timedelta
@@ -292,6 +293,7 @@ class BaseNetCDFReader(BaseDatasetReader):
                 f'date {start_date} - {end_date} with vars: {variables}'
             )
             logger.error(ex)
+            logger.error(traceback.format_exc())
         return result
 
     def find_locations(self, val: xrDataset) -> List[Point]:


### PR DESCRIPTION
This PR is for #125 and #130.

This PR will set the chunksize for Salient zarr file to:

- With ensemble: (10, 20, 50, 20, 20)
- Without ensemble: (10, 20, 20, 20)

Coordinates in order: forecast_date, forecast_day_idx, ensemble, lat, lon.
The max memory for a chunk would be: 10 x 20 x 50 x 20 x 20 x 4 bytes = ~16MB.

I have tried increasing the chunksize for forecast_day_idx to 30 so the chunksize would be (10, 30, 50, 20, 20). But, the memory that ingestor needs increased three folds, from 2.3GB to more than 6GB.

I think the chunksize 20 for forecast_day_idx still make sense because API can fetch up to 20 days of forecast in single chunk.
