### PR TITLE
fix missing image lib from salientsdk

### DIFF
--- a/deployment/plumber/Dockerfile
+++ b/deployment/plumber/Dockerfile
@@ -27,7 +27,8 @@ RUN install2.r --error tidyverse tidygam mgcv ggpubr classInt zoo
 
 # Install pip packages
 ADD deployment/docker/requirements.txt /requirements.txt
-RUN python3 -m pip install setuptools
+RUN apt-get remove -y python3-pil
+RUN python3 -m pip install setuptools Pillow
 # Fix uwsgi build failure missing cc1
 ARG CPUCOUNT=1
 RUN python3 -m pip install -r /requirements.txt


### PR DESCRIPTION
Fix issue on plumber container: https://kartoza-pty-ltd.sentry.io/issues/9247935/?alert_rule_id=48384&alert_timestamp=1728506576943&alert_type=email&environment=production&notification_uuid=2b4943f3-7fb8-4741-89aa-dd9438a2f8dc&project=4507745823424592&referrer=alert_email

ImportError
cannot import name '_imaging' from 'PIL' (/usr/lib/python3/dist-packages/PIL/__init__.py)
