### PR TITLE
add cleanup task to remove old R execution logs

### DIFF
--- a/django_project/core/celery.py
+++ b/django_project/core/celery.py
@@ -68,6 +68,11 @@ app.conf.beat_schedule = {
         'task': 'run_daily_ingestor',
         # Run everyday at 00:00 UTC
         'schedule': crontab(minute='00', hour='00'),
+    },
+    'cleanup-r-execution-logs': {
+        'task': 'cleanup_r_execution_logs',
+        # Run every first day of each month at 00:00 UTC
+        'schedule': crontab(minute=0, hour=0, day_of_month=1),
     }
 }
 

--- a/django_project/spw/apps.py
+++ b/django_project/spw/apps.py
@@ -12,3 +12,7 @@ class SpwConfig(AppConfig):
 
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'spw'
+
+    def ready(self):
+        """App ready handler."""
+        from spw.tasks import cleanup_r_execution_logs  # noqa

--- a/django_project/spw/tasks.py
+++ b/django_project/spw/tasks.py
@@ -4,9 +4,12 @@ Tomorrow Now GAP.
 
 .. note:: SPW Tasks
 """
+from datetime import timedelta
 from celery import shared_task
 from celery.utils.log import get_task_logger
+from django.utils import timezone
 
+from spw.models import RModelExecutionLog
 from spw.utils.plumber import (
     kill_r_plumber_process,
     spawn_r_plumber,
@@ -15,6 +18,7 @@ from spw.utils.plumber import (
 
 
 logger = get_task_logger(__name__)
+REMOVE_AFTER_DAYS = 30
 
 
 @shared_task(name="start_plumber_process")
@@ -31,3 +35,12 @@ def start_plumber_process():
         logger.info(f'plumber process pid {plumber_process.pid}')
     else:
         raise RuntimeError('Cannot execute plumber process!')
+
+
+@shared_task(name="cleanup_r_execution_logs")
+def cleanup_r_execution_logs():
+    """Cleanup past RModelExecutionLog."""
+    datetime_filter = timezone.now() - timedelta(days=REMOVE_AFTER_DAYS)
+    RModelExecutionLog.objects.filter(
+        start_date_time__lte=datetime_filter
+    ).delete()


### PR DESCRIPTION
The task will run on the first day of each month and cleanup logs older than 30days.