### PR TITLE
remove unused section swagger ui

### DIFF
--- a/django_project/gap_api/templates/gap/swagger-ui.html
+++ b/django_project/gap_api/templates/gap/swagger-ui.html
@@ -109,8 +109,8 @@
                                 });
 
                                 // check if has mode=full
-                                let searchParams = new URLSearchParams(window.location.search);
-                                let mode = searchParams.get('mode');
+                                var searchParams = new URLSearchParams(window.location.search);
+                                var mode = searchParams.get('mode');
                                 if (mode !== 'full') {
                                     // hide id get_measurement__responses
                                     $('#get_measurement__responses').hide();
@@ -119,6 +119,18 @@
                                     .html('.response-col_description div:nth-of-type(2) { display: none; } .curl-command { display: none; } div.responses-inner > div > h4 { display: none; }')
                                     .appendTo('head');
                                 }
+                                var startDateSelector = '#operations-Weather_\\\\\\&_Climate_Data-get-measurement > div.no-margin > div > div.opblock-section > div.parameters-container > div > table > tbody > tr[data-param-name="start_date"] > td.parameters-col_description > div:nth-child(1)';
+                                $(startDateSelector).after('<div class="markdown"><p><i>Example</i>: 2020-01-01</p></div>');
+                                var endDateSelector = '#operations-Weather_\\\\\\&_Climate_Data-get-measurement > div.no-margin > div > div.opblock-section > div.parameters-container > div > table > tbody > tr[data-param-name="end_date"] > td.parameters-col_description > div:nth-child(1)';
+                                $(endDateSelector).after('<div class="markdown"><p><i>Example</i>: 2020-01-10</p></div>');
+                                var latSelector = '#operations-Weather_\\\\\\&_Climate_Data-get-measurement > div.no-margin > div > div.opblock-section > div.parameters-container > div > table > tbody > tr[data-param-name="lat"] > td.parameters-col_description > div:nth-child(1)';
+                                $(latSelector).after('<div class="markdown"><p><i>Example</i>: 0.5878374</p></div>');
+                                var lonSelector = '#operations-Weather_\\\\\\&_Climate_Data-get-measurement > div.no-margin > div > div.opblock-section > div.parameters-container > div > table > tbody > tr[data-param-name="lon"] > td.parameters-col_description > div:nth-child(1)';
+                                $(lonSelector).after('<div class="markdown"><p><i>Example</i>: 35.8560798</p></div>');
+                                var bboxSelector = '#operations-Weather_\\\\\\&_Climate_Data-get-measurement > div.no-margin > div > div.opblock-section > div.parameters-container > div > table > tbody > tr[data-param-name="bbox"] > td.parameters-col_description > div:nth-child(1)';
+                                $(bboxSelector).after('<div class="markdown"><p><i>Example</i>: 37.09,0.44,39.35,2.41</p></div>');
+                                var altitudesSelector = '#operations-Weather_\\\\\\&_Climate_Data-get-measurement > div.no-margin > div > div.opblock-section > div.parameters-container > div > table > tbody > tr[data-param-name="altitudes"] > td.parameters-col_description > div:nth-child(1)';
+                                $(altitudesSelector).after('<div class="markdown"><p><i>Example</i>: 0,20000</p></div>');
                             }, 200);
                           }
                       }

--- a/django_project/gap_api/templates/gap/swagger-ui.html
+++ b/django_project/gap_api/templates/gap/swagger-ui.html
@@ -107,6 +107,18 @@
                                 $productSelect.on('change', function() {
                                     change_item_list($(this).val());
                                 });
+
+                                // check if has mode=full
+                                let searchParams = new URLSearchParams(window.location.search);
+                                let mode = searchParams.get('mode');
+                                if (mode !== 'full') {
+                                    // hide id get_measurement__responses
+                                    $('#get_measurement__responses').hide();
+                                    $('<style>')
+                                    .prop('type', 'text/css')
+                                    .html('.response-col_description div:nth-of-type(2) { display: none; } .curl-command { display: none; } div.responses-inner > div > h4 { display: none; }')
+                                    .appendTo('head');
+                                }
                             }, 200);
                           }
                       }


### PR DESCRIPTION
Fix https://github.com/kartoza/tomorrownow_gap/issues/272

Preview:
![2025-03-27_08-15](https://github.com/user-attachments/assets/c78f63a6-ea3f-4151-8a62-8111a0aa4745)

![2025-03-27_08-15_1](https://github.com/user-attachments/assets/edcfa28b-dcf2-4d3a-8c73-f0e79e32de14)

Error - 404
![2025-03-27_08-16](https://github.com/user-attachments/assets/2ee5350a-7273-4da7-aadd-a690f6db4cc6)


The original sections can still displayed by using mode=full in the request parameter.
E.g. /api/v1/docs/?mode=full


Also added an example values,
![image](https://github.com/user-attachments/assets/66c16d69-089f-4dca-98c8-55e2782fbdd3)

