### PR TITLE
add pg_use_copy to ogr2ogr command

### DIFF
--- a/django_project/gap/ingestor/farm_registry.py
+++ b/django_project/gap/ingestor/farm_registry.py
@@ -295,7 +295,10 @@ class DCASFarmRegistryIngestor(BaseIngestor):
             vrt_file_path,
             '-nln',
             self.table_name,
-            '-append'
+            '-append',
+            '--config',
+            'PG_USE_COPY',
+            'YES'
         ]
         subprocess.run(cmd_list, check=True)
         ogr2_total_time = time.time() - ogr2_start_time
@@ -551,3 +554,8 @@ class DCASFarmRegistryIngestor(BaseIngestor):
                 self.session.additional_config.update(self.execution_times)
             else:
                 self.session.additional_config = self.execution_times
+
+            # store the farm registry group id
+            self.session.additional_config['farm_registry_group_id'] = (
+                self.group.id
+            )


### PR DESCRIPTION
Using -append command, the ogr2ogr command becomes slower when inserting data from farm registry csv file. Adding the pg_use_copy makes the process faster to write data into temp table.

Ref: https://blog.rtwilson.com/how-to-speed-up-appending-to-postgis-tables-with-ogr2ogr/