### PR TITLE
separate process for running celery beat in the worker

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -59,7 +59,7 @@ services:
   worker:
     <<: *default-common-django
     entrypoint: [ ]
-    command: 'celery -A core worker --beat -l info  --scheduler django_celery_beat.schedulers:DatabaseScheduler'
+    command: 'supervisord -c /supervisord.conf'
     links:
       - db
       - redis

--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -6,7 +6,8 @@ RUN apt-get update -y && \
     spatialite-bin libsqlite3-mod-spatialite \
     python3-dev python3-gdal python3-psycopg2 python3-ldap \
     python3-pip python3-pil python3-lxml python3-pylibmc \
-    uwsgi uwsgi-plugin-python3 build-essential gdal-bin
+    uwsgi uwsgi-plugin-python3 build-essential gdal-bin \
+    supervisor
 
 # Install pip packages
 ADD deployment/docker/requirements.txt /requirements.txt
@@ -23,6 +24,8 @@ ADD django_project /home/web/django_project
 EXPOSE 8080
 
 ADD deployment/docker/uwsgi.conf /uwsgi.conf
+# Add supervisord config for worker
+ADD deployment/docker/supervisord.conf /supervisord.conf
 
 WORKDIR /home/web/django_project
 ENTRYPOINT ["/home/web/django_project/entrypoint.sh"]

--- a/deployment/docker/supervisord.conf
+++ b/deployment/docker/supervisord.conf
@@ -1,0 +1,22 @@
+[supervisord]
+nodaemon=true
+
+[program:celery-worker]
+command=celery -A core worker -l info
+directory=/home/web/django_project
+autostart=true
+autorestart=true
+stdout_logfile=/dev/fd/1
+stderr_logfile=/dev/fd/2
+stdout_logfile_maxbytes = 0
+stderr_logfile_maxbytes = 0
+
+[program:celery-beat]
+command=celery -A core beat -l info --scheduler django_celery_beat.schedulers:DatabaseScheduler
+directory=/home/web/django_project
+autostart=true
+autorestart=true
+stdout_logfile=/dev/fd/1
+stderr_logfile=/dev/fd/2
+stdout_logfile_maxbytes = 0
+stderr_logfile_maxbytes = 0

--- a/deployment/docker/supervisord.conf
+++ b/deployment/docker/supervisord.conf
@@ -1,5 +1,8 @@
 [supervisord]
 nodaemon=true
+pidfile=/tmp/supervisord.pid
+logfile=/dev/null
+childlogdir=/tmp
 
 [program:celery-worker]
 command=celery -A core worker -l info


### PR DESCRIPTION
Celery beat has issue when running with worker. This PR will separate the process to run beat and worker using supervisor.

@LokoMoloko98 I need your help to add the supervisord.conf to the deployment and change the worker commands to `supervisord -c /supervisord.conf`