### PR TITLE
Fix: ensure reset password URL is safe in email templates

### DIFF
--- a/django_project/frontend/templates/account/email/email_set_password_message.html
+++ b/django_project/frontend/templates/account/email/email_set_password_message.html
@@ -12,7 +12,7 @@
       To choose your new password for your Global Access Platform account, just click the link below:
     </p>
     <p>
-      <a href="{{ reset_password_url }}" style="color: #1a73e8; text-decoration: none;">
+      <a href="{{ reset_password_url|safe }}" style="color: #1a73e8; text-decoration: none;">
         Set your new password
       </a>
     </p>

--- a/django_project/frontend/templates/account/email/email_set_password_message.txt
+++ b/django_project/frontend/templates/account/email/email_set_password_message.txt
@@ -2,7 +2,7 @@ Hi {{ user.get_full_name|default:user.username|default:"there" }},
 
 To choose your new password for your Global Access Platform account, click the link below:
 
-{{ reset_password_url }}
+{{ reset_password_url|safe }}
 
 If you didn’t make this request, you can safely ignore this message.
 


### PR DESCRIPTION
It was breaking the returned url: 
`http://localhost:8000/signin?uid=MTE4&amp;token=crpkis-b7d2d8a7c3aef5f174675194fa1edd6c`
which would redirect user to signup page instead
![Screenshot From 2025-06-20 21-32-37](https://github.com/user-attachments/assets/538cdf61-618a-4995-8a70-66b3bd94bc7f)


Fixed now returns:

`http://localhost:8000/signin?uid=MTE3&token=crpksv-a92f4dd2a73f05d5c24a93fd4dad08b4`

Now returns the Reset password page
![Screenshot From 2025-06-20 21-32-21](https://github.com/user-attachments/assets/4a2a0010-fe48-4255-a076-dc50fdd36d50)
