### PR TITLE
Fix salient historical on year 2020

### DIFF
--- a/django_project/gap/ingestor/salient.py
+++ b/django_project/gap/ingestor/salient.py
@@ -481,13 +481,18 @@ class SalientIngestor(BaseZarrIngestor):
                     new_data = {}
 
                     for var_name in subset_vars:
+                        if var_name not in da.variables:
+                            logger.warning(
+                                f'Variable {var_name} not found in dataset!'
+                            )
+                            continue
                         subset_da = da[var_name]
                         new_data[var_name] = subset_da.data
 
                     # write to zarr
                     self._update_by_region(
                         new_forecast_date, forecast_date_idx,
-                        lat_arr, lon_arr, subset_vars, new_data
+                        lat_arr, lon_arr, list(new_data.keys()), new_data
                     )
 
                     total_processed += 1

--- a/django_project/gap/providers/salient.py
+++ b/django_project/gap/providers/salient.py
@@ -16,7 +16,7 @@ from xarray.core.dataset import Dataset as xrDataset
 from shapely.geometry import shape
 from django.db.models.functions import Cast
 from django.db.models.fields import DateField
-from django.contrib.postgres.fields.jsonb import KeyTextTransform
+from django.db.models.fields.json import KeyTextTransform
 
 from gap.models import (
     Dataset,

--- a/django_project/gap/providers/salient.py
+++ b/django_project/gap/providers/salient.py
@@ -14,7 +14,6 @@ import xarray as xr
 import pandas as pd
 from xarray.core.dataset import Dataset as xrDataset
 from shapely.geometry import shape
-from django.db.models import Q
 from django.db.models.functions import Cast
 from django.db.models.fields import DateField
 from django.contrib.postgres.fields.jsonb import KeyTextTransform

--- a/django_project/gap/tests/providers/test_salient.py
+++ b/django_project/gap/tests/providers/test_salient.py
@@ -371,7 +371,9 @@ class TestSalientZarrReader(TestCase):
             format=DatasetStore.ZARR,
             is_latest=False,
             metadata={
-                'is_historical': True
+                'is_historical': True,
+                'start_date': '2024-01-01',
+                'end_date': '2024-12-31'
             }
         )
         reader = SalientZarrReader(


### PR DESCRIPTION
Fix https://github.com/kartoza/tomorrownow_gap/issues/733

Need to add the new zarr for 2020 and add the metadata 'start_date' and 'end_date' to all historical zarr data source metadata.