### PR TITLE
Feat spw drop calc ref date

### DIFF
--- a/django_project/core/tests/test_date.py
+++ b/django_project/core/tests/test_date.py
@@ -285,7 +285,7 @@ class TestGetPreviousDay(TestCase):
         """Set up test fixtures with known reference dates."""
         # Wednesday, September 17, 2025
         self.test_date_wed = date(2025, 9, 17)
-        # Monday, September 15, 2025  
+        # Monday, September 15, 2025
         self.test_date_mon = date(2025, 9, 15)
         # Sunday, September 21, 2025
         self.test_date_sun = date(2025, 9, 21)
@@ -302,7 +302,7 @@ class TestGetPreviousDay(TestCase):
         """Test finding all previous days from Wednesday."""
         test_cases = [
             (0, date(2025, 9, 15)),  # Previous Monday
-            (1, date(2025, 9, 16)),  # Previous Tuesday  
+            (1, date(2025, 9, 16)),  # Previous Tuesday
             (2, date(2025, 9, 10)),  # Previous Wednesday (7 days back)
             (3, date(2025, 9, 11)),  # Previous Thursday
             (4, date(2025, 9, 12)),  # Previous Friday
@@ -396,7 +396,7 @@ class TestGetPreviousDay(TestCase):
             self.assertEqual(result, expected_monday)
 
         with self.subTest("day_number=-1"):
-            # day_number -1 should behave like 6 (Sunday)  
+            # day_number -1 should behave like 6 (Sunday)
             result = get_previous_day(-1, self.test_date_wed)
             expected_sunday = get_previous_day(6, self.test_date_wed)
             self.assertEqual(result, expected_sunday)

--- a/django_project/core/utils/date.py
+++ b/django_project/core/utils/date.py
@@ -5,7 +5,7 @@ Tomorrow Now GAP.
 .. note:: Utilities for date.
 """
 
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 import calendar
 
 
@@ -131,3 +131,40 @@ def closest_leap_year(year):
         if calendar.isleap(lower):
             return lower
         lower -= 1
+
+
+def get_previous_day(day_number, reference_date=None):
+    """
+    Get the previous occurrence of a specific day of the week.
+
+    Args:
+        day_number (int): Day of the week (0=Monday, 1=Tuesday, ..., 6=Sunday)
+        reference_date (datetime, optional): Reference date. Defaults to today.
+
+    Returns:
+        datetime: The date of the previous occurrence of the specified day
+
+    Example:
+        If today is Wednesday (Sep 17, 2025) and day_number=3 (Thursday),
+        returns Thursday Sep 11, 2025
+    """
+    if reference_date is None:
+        reference_date = datetime.now().date()
+    elif isinstance(reference_date, datetime):
+        reference_date = reference_date.date()
+
+    # Get the current day of the week (0=Monday, 6=Sunday)
+    current_day = reference_date.weekday()
+
+    # Calculate days to go back
+    days_back = (current_day - day_number + 7) % 7
+
+    # If the result is 0, it means today is the target day,
+    # so we want the previous occurrence (7 days back)
+    if days_back == 0:
+        days_back = 7
+
+    # Calculate the previous date
+    previous_date = reference_date - timedelta(days=days_back)
+
+    return previous_date

--- a/django_project/spw/generator/crop_insight.py
+++ b/django_project/spw/generator/crop_insight.py
@@ -11,6 +11,7 @@ import pytz
 from django.db import transaction
 from django.utils import timezone
 
+from core.utils.date import get_previous_day
 from gap.models.crop_insight import (
     FarmSuitablePlantingWindowSignal, FarmShortTermForecast,
     FarmShortTermForecastData
@@ -53,6 +54,10 @@ class CropInsightFarmGenerator:
         self.reference_date = (
             date.fromisoformat(ref_date_str) if ref_date_str else None
         )
+        if self.reference_date:
+            self.reference_date = get_previous_day(
+                self.reference_date.weekday(), self.today
+            )
 
     def return_float(self, value):
         """Return float value."""

--- a/django_project/spw/tests/test_crop_insight_generator.py
+++ b/django_project/spw/tests/test_crop_insight_generator.py
@@ -607,7 +607,7 @@ class TestCropInsightGenerator(TestCase):
         # Create a previous tier 1 signal on the reference date
         FarmSuitablePlantingWindowSignal.objects.create(
             farm=self.farm,
-            generated_date=date(2023, 7, 7),
+            generated_date=date(2023, 7, 14),
             signal='Plant NOW Tier 1a'
         )
 
@@ -682,6 +682,9 @@ class TestCropInsightGenerator(TestCase):
         ).last()
         self.assertEqual(last_spw.signal, 'Plant NOW Tier 1b')
         self.assertTrue(last_spw.is_sent_before)
+        self.assertEqual(
+            last_spw.prev_reference_date, date(2023, 7, 14)
+        )
 
         # We mock the send email to get the attachments
         attachments = []


### PR DESCRIPTION
For #847

Given reference date 2025-09-10, then if today is 2025-09-25, then the logic will check for date 2025-09-24 (same Wednesday) since we agree that KALRO will send/delivery messages on the same wednesday.